### PR TITLE
SVM Light Record Serialization

### DIFF
--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/SVMLightRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/SVMLightRecordReader.java
@@ -85,7 +85,7 @@ public class SVMLightRecordReader extends LineRecordReader {
 
             // 1. class
             double classVal = Double.parseDouble(tok.nextToken());
-            int numRecordsAdded = 0;
+            int numAttributesAdded = 0;
             // 2. attributes
             while (tok.hasMoreTokens()) {
                 col  = tok.nextToken();
@@ -96,18 +96,18 @@ public class SVMLightRecordReader extends LineRecordReader {
                 if (col.startsWith("qid:"))
                     continue;
                 // actual value
-                index = Integer.parseInt(col.substring(0, col.indexOf(":")));
-                if(index > numRecordsAdded) {
-                    int totalDiff = Math.abs(numRecordsAdded - index);
-                    for(int i = numRecordsAdded; i < index; i++) {
+                index = Integer.parseInt(col.substring(0, col.indexOf(":"))) - 1;
+                if(index > numAttributesAdded) {
+                    int totalDiff = Math.abs(numAttributesAdded - index);
+                    for(int i = numAttributesAdded; i < index; i++) {
                         ret.add(new DoubleWritable(0.0));
 
                     }
-                    numRecordsAdded += totalDiff;
+                    numAttributesAdded += totalDiff;
                 }
                 value = Double.parseDouble(col.substring(col.indexOf(":") + 1));
                 ret.add(new DoubleWritable(value));
-                numRecordsAdded++;
+                numAttributesAdded++;
             }
 
             if(numAttributes >= 1 && ret.size() < numAttributes) {

--- a/canova-api/src/test/java/org/canova/api/records/reader/impl/SVMRecordWriterTest.java
+++ b/canova-api/src/test/java/org/canova/api/records/reader/impl/SVMRecordWriterTest.java
@@ -64,16 +64,13 @@ public class SVMRecordWriterTest {
         RecordReader reader = new CSVRecordReader();
         List<Collection<Writable>> records = new ArrayList<>();
         reader.initialize(split);
-        int count = 0;
         while(reader.hasNext()) {
             Collection<Writable> record = reader.next();
-            records.add(record);
             assertEquals(5, record.size());
             records.add(record);
-            count++;
         }
 
-        assertEquals(150,count);
+        assertEquals(150,records.size());
         File out = new File("iris_out.txt");
         out.deleteOnExit();
         RecordWriter writer = new SVMLightRecordWriter(out,true);
@@ -81,6 +78,7 @@ public class SVMRecordWriterTest {
             writer.write(record);
 
         writer.close();
+        records.clear();
 
         RecordReader svmReader = new SVMLightRecordReader();
         InputSplit svmSplit = new FileSplit(out);
@@ -88,15 +86,10 @@ public class SVMRecordWriterTest {
         assertTrue(svmReader.hasNext());
         while(svmReader.hasNext()) {
             Collection<Writable> record = svmReader.next();
-            records.add(record);
             assertEquals(5, record.size());
             records.add(record);
-            count++;
         }
-
-
-
-
+        assertEquals(150,records.size());
     }
 
     @Test


### PR DESCRIPTION
The SVMLightRecordReader was treating SVM Light feature
vectors as 0-based instead of 1-based. This was causing it
to read in incorrectly-sized vectors.

The unit test also added deserialized records to its
accumulator list multiple times and did not clear this list
between tests.

Also changed the variable name numRecordsAdded to the
more accurate numAttributesAdded.