### PR TITLE
Classpathresource startingslash

### DIFF
--- a/canova-api/src/main/java/org/canova/api/util/ClassPathResource.java
+++ b/canova-api/src/main/java/org/canova/api/util/ClassPathResource.java
@@ -53,6 +53,11 @@ public class ClassPathResource {
 
         URL url = loader.getResource(this.resourceName);
         if (url == null) {
+            // try to check for mis-used starting slash
+            if (this.resourceName.startsWith("/")) {
+                url = loader.getResource(this.resourceName.replaceFirst("[\\\\/]",""));
+                if (url != null) return url;
+            }
             throw new IllegalStateException("Resource '" + this.resourceName + "' cannot be found.");
         }
         return url;

--- a/canova-api/src/main/java/org/canova/api/util/ClassPathResource.java
+++ b/canova-api/src/main/java/org/canova/api/util/ClassPathResource.java
@@ -54,8 +54,14 @@ public class ClassPathResource {
         URL url = loader.getResource(this.resourceName);
         if (url == null) {
             // try to check for mis-used starting slash
+            // TODO: see TODO below
             if (this.resourceName.startsWith("/")) {
                 url = loader.getResource(this.resourceName.replaceFirst("[\\\\/]",""));
+                if (url != null) return url;
+            } else {
+                // try to add slash, to make clear it's not an issue
+                // TODO: change this mechanic to actual path purifier
+                url = loader.getResource("/" + this.resourceName);
                 if (url != null) return url;
             }
             throw new IllegalStateException("Resource '" + this.resourceName + "' cannot be found.");

--- a/canova-api/src/main/java/org/canova/api/util/ClassPathResource.java
+++ b/canova-api/src/main/java/org/canova/api/util/ClassPathResource.java
@@ -91,6 +91,14 @@ public class ClassPathResource {
 
                 ZipFile zipFile = new ZipFile(url.getFile());
                 ZipEntry entry = zipFile.getEntry(this.resourceName);
+                if (entry == null) {
+                    if (this.resourceName.startsWith("/")) {
+                        entry = zipFile.getEntry(this.resourceName.replaceFirst("/",""));
+                        if (entry == null) {
+                            throw new FileNotFoundException("Resource " + this.resourceName + " not found");
+                        }
+                    } else throw new FileNotFoundException("Resource " + this.resourceName + " not found");
+                }
 
                 InputStream stream = zipFile.getInputStream(entry);
                 FileOutputStream outputStream = new FileOutputStream(file);

--- a/canova-api/src/test/java/org/canova/api/util/ClassPathResourceTest.java
+++ b/canova-api/src/test/java/org/canova/api/util/ClassPathResourceTest.java
@@ -11,7 +11,7 @@ import java.io.InputStreamReader;
 import static org.junit.Assert.*;
 
 /**
- * Created by fartovii on 03.12.15.
+ * @author raver119@gmail.com
  */
 public class ClassPathResourceTest {
 
@@ -29,6 +29,14 @@ public class ClassPathResourceTest {
     }
 
     @Test
+    public void testGetFileSlash1() throws Exception {
+        File intFile = new ClassPathResource("/iris.dat").getFile();
+
+        assertTrue(intFile.exists());
+        assertEquals(2700, intFile.length());
+    }
+
+    @Test
     public void testGetFileWithSpace1() throws Exception {
         File intFile = new ClassPathResource("csvsequence test.txt").getFile();
 
@@ -39,6 +47,24 @@ public class ClassPathResourceTest {
     @Test
     public void testInputStream() throws Exception {
         ClassPathResource resource = new ClassPathResource("csvsequence_1.txt");
+        File intFile = resource.getFile();
+
+        assertEquals(60, intFile.length());
+
+        InputStream stream = resource.getInputStream();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+        String line = "";
+        int cnt = 0;
+        while ((line = reader.readLine()) != null) {
+            cnt++;
+        }
+
+        assertEquals(5, cnt);
+    }
+
+    @Test
+    public void testInputStreamSlash() throws Exception {
+        ClassPathResource resource = new ClassPathResource("/csvsequence_1.txt");
         File intFile = resource.getFile();
 
         assertEquals(60, intFile.length());


### PR DESCRIPTION
ClassPathResource fix that addresses difference between starting slash handling at classpath and jar-packed resources.