### PR TITLE
Remove ListIterator cast

### DIFF
--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/LineRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/LineRecordReader.java
@@ -83,7 +83,7 @@ public class LineRecordReader implements RecordReader {
             currIndex++;
             try {
                 close();
-                iter = (ListIterator) IOUtils.lineIterator(new InputStreamReader(locations[currIndex].toURL().openStream()));
+                iter = IOUtils.lineIterator(new InputStreamReader(locations[currIndex].toURL().openStream()));
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
Casting LineIterator (which IOUtils.lineIterator() returns) to a
ListIterator throws a ClassCastException. This is because LineIterator
is not a ListIterator.

This removes the cast on line 86 to make it the same structure as line
63.