### PR TITLE
Fix null pointer dereference

### DIFF
--- a/canova-api/src/main/java/org/canova/api/split/FileSplit.java
+++ b/canova-api/src/main/java/org/canova/api/split/FileSplit.java
@@ -76,7 +76,7 @@ public class FileSplit extends BaseInputSplit {
     protected void initialize() {
         Collection<File> subFiles;
 
-        if(rootDir == null && rootDir.exists())
+        if(rootDir == null)
             throw new IllegalArgumentException("File must not be null");
 
         if(rootDir.isDirectory()) {


### PR DESCRIPTION
A null rootDir will throw a NullPointerException instead of an IllegalArgumentException.