### PR TITLE
Fix implementation of rootMeansSquaredError

### DIFF
--- a/canova-api/src/main/java/org/canova/api/util/MathUtils.java
+++ b/canova-api/src/main/java/org/canova/api/util/MathUtils.java
@@ -751,11 +751,11 @@ public class MathUtils {
    * @return the root means squared error for two data sets
    */
   public static double rootMeansSquaredError(double[] real, double[] predicted) {
-    double ret = 1 / real.length;
+    double ret = 0.0;
     for (int i = 0; i < real.length; i++) {
       ret += Math.pow((real[i] - predicted[i]), 2);
     }
-    return Math.sqrt(ret);
+    return Math.sqrt(ret / real.length);
   }//end rootMeansSquaredError
 
   /**


### PR DESCRIPTION
In the previous implementation, because 1 and real.length are integers,
the result of ret in the first line will be that of an integer division,
which will be zero because real.length is always 1 or greater (if the
array is not empty - this also needs further fixing).

Anyway, the previous implementation essentially returns the root of the
sum of squared errors, not the root of the mean of the squared errors.

The fix divides the sum ret by real.length (hence computing the mean)
before the Math.sqrt().