### PR TITLE
Fix implementation of adjustedrSquared

### DIFF
--- a/canova-api/src/main/java/org/canova/api/util/MathUtils.java
+++ b/canova-api/src/main/java/org/canova/api/util/MathUtils.java
@@ -798,7 +798,7 @@ public class MathUtils {
    * @return an adjusted r^2 for degrees of freedom
    */
   public static double adjustedrSquared(double rSquared, int numRegressors, int numDataPoints) {
-    double divide = (numDataPoints - 1) / (numDataPoints - numRegressors - 1);
+    double divide = (numDataPoints - 1.0) / (numDataPoints - numRegressors - 1.0);
     double rSquaredDiff = 1 - rSquared;
     return 1 - (rSquaredDiff * divide);
   }


### PR DESCRIPTION
In the previous implementation, because numRegressors and numDataPoints
are integers, the result of divide in the first line will be that of an
integer division.

The fix replaces the 1s by 1.0s to implicitly cast the integers as
doubles and perform double division.