### PR TITLE
Fix bug in LineRecordReader

### DIFF
--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/LineRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/LineRecordReader.java
@@ -78,29 +78,45 @@ public class LineRecordReader implements RecordReader {
         if(iter.hasNext()) {
             ret.add(new Text(iter.next()));
             return ret;
-        }
-        else {
-            currIndex++;
-            try {
-                close();
-                iter = IOUtils.lineIterator(new InputStreamReader(locations[currIndex].toURL().openStream()));
-            } catch (IOException e) {
-                e.printStackTrace();
+        } else {
+            if ( !(inputSplit instanceof StringSplit) && currIndex < locations.length-1 ) {
+                currIndex++;
+                try {
+                    close();
+                    iter = IOUtils.lineIterator(new InputStreamReader(locations[currIndex].toURL().openStream()));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+
+                if(iter.hasNext()) {
+                    ret.add(new Text(iter.next()));
+                    return ret;
+                }
             }
 
-            if(iter.hasNext()) {
-                ret.add(new Text(iter.next()));
-                return ret;
-            }
-
+            throw new NoSuchElementException("No more elements found!");
         }
-
-        throw new NoSuchElementException("No more elements found!");
     }
 
     @Override
     public boolean hasNext() {
-        return iter != null && iter.hasNext();
+        if ( iter != null && iter.hasNext() ) {
+            return true;
+        } else {
+            if ( !(inputSplit instanceof StringSplit) && currIndex < locations.length-1 ) {
+                currIndex++;
+                try {
+                    close();
+                    iter = IOUtils.lineIterator(new InputStreamReader(locations[currIndex].toURL().openStream()));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+
+                return iter.hasNext();
+            }
+
+            return false;
+        }
     }
 
     @Override

--- a/canova-api/src/test/java/org/canova/api/records/reader/impl/LineReaderTest.java
+++ b/canova-api/src/test/java/org/canova/api/records/reader/impl/LineReaderTest.java
@@ -43,20 +43,31 @@ public class LineReaderTest {
 
     @Test
     public void testLineReader() throws Exception {
-        File tmp = new File("tmp.txt");
-        FileUtils.writeLines(tmp, Arrays.asList("1","2","3"));
-        InputSplit split = new FileSplit(tmp);
-        tmp.deleteOnExit();
+        File tmpdir = new File("tmpdir");
+        tmpdir.mkdir();
+
+        File tmp1 = new File("tmpdir/tmp1.txt");
+        File tmp2 = new File("tmpdir/tmp2.txt");
+        File tmp3 = new File("tmpdir/tmp3.txt");
+
+        FileUtils.writeLines(tmp1, Arrays.asList("1","2","3"));
+        FileUtils.writeLines(tmp2, Arrays.asList("4","5","6"));
+        FileUtils.writeLines(tmp3, Arrays.asList("7","8","9"));
+
+        InputSplit split = new FileSplit(tmpdir);
+
         RecordReader reader = new LineRecordReader();
         reader.initialize(split);
+
         int count = 0;
         while(reader.hasNext()) {
             assertEquals(1,reader.next().size());
             count++;
         }
 
-        assertEquals(3,count);
+        assertEquals(9, count);
 
+        FileUtils.deleteDirectory(tmpdir);
     }
 
 


### PR DESCRIPTION
The previous implementation of LineRecordReader did not work for the
multiple-file case: hasNext() did not check for a next file and
initialise a new iterator.

This implementation fixes the bug, and cleans up the code with a bulk
of the work done in a new method called readLine(). The unit test
LineReaderTest is also modified accordingly.