### PR TITLE
Add NativeImageLoader that uses JavaCV to load images

### DIFF
--- a/canova-nd4j/canova-nd4j-image/pom.xml
+++ b/canova-nd4j/canova-nd4j-image/pom.xml
@@ -86,6 +86,22 @@
             <version>3.1.1</version>
            
         </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacv</artifactId>
+            <version>1.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco.javacpp-presets</groupId>
+            <artifactId>opencv</artifactId>
+            <version>3.1.0-1.2</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/loader/BaseImageLoader.java
+++ b/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/loader/BaseImageLoader.java
@@ -5,11 +5,13 @@ import org.canova.api.records.reader.RecordReader;
 import org.canova.api.split.LimitFileSplit;
 import org.canova.api.util.ArchiveUtils;
 import org.canova.image.recordreader.ImageRecordReader;
+import org.nd4j.linalg.api.ndarray.INDArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URL;
 import java.util.Map;
@@ -18,13 +20,27 @@ import java.util.Random;
 /**
  * Created by nyghtowl on 12/17/15.
  */
-public class BaseImageLoader implements Serializable {
+public abstract class BaseImageLoader implements Serializable {
 
     protected static final Logger log = LoggerFactory.getLogger(BaseImageLoader.class);
 
     public static final File BASE_DIR = new File(System.getProperty("user.home"));
     public static final String[] ALLOWED_FORMATS = {"tif", "jpg", "png", "jpeg", "bmp", "JPEG", "JPG", "TIF", "PNG"};
     protected Random rng = new Random(System.currentTimeMillis());
+
+    protected int height = -1;
+    protected int width = -1;
+    protected int channels = -1;
+    protected boolean centerCropIfNeeded = false;
+
+    public String[] getAllowedFormats() {
+        return ALLOWED_FORMATS;
+    }
+
+    public abstract INDArray asRowVector(File f) throws IOException;
+    public abstract INDArray asRowVector(InputStream inputStream) throws IOException;
+    public abstract INDArray asMatrix(File f) throws IOException;
+    public abstract INDArray asMatrix(InputStream inputStream) throws IOException;
 
     public void downloadAndUntar(Map urlMap, File fullDir) {
         try {

--- a/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/loader/CifarLoader.java
+++ b/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/loader/CifarLoader.java
@@ -3,6 +3,7 @@ package org.canova.image.loader;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.nd4j.linalg.api.ndarray.INDArray;
 
 import java.io.*;
 import java.util.*;
@@ -57,6 +58,26 @@ public class CifarLoader extends BaseImageLoader implements Serializable {
 
     public CifarLoader(){
         load();
+    }
+
+    @Override
+    public INDArray asRowVector(File f) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public INDArray asRowVector(InputStream inputStream) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public INDArray asMatrix(File f) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public INDArray asMatrix(InputStream inputStream) throws IOException {
+        throw new UnsupportedOperationException();
     }
 
     public void generateMaps() {

--- a/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/loader/LFWLoader.java
+++ b/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/loader/LFWLoader.java
@@ -24,9 +24,11 @@ package org.canova.image.loader;
 import org.canova.api.records.reader.RecordReader;
 import org.canova.api.split.LimitFileSplit;
 import org.canova.image.recordreader.ImageRecordReader;
+import org.nd4j.linalg.api.ndarray.INDArray;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.util.*;
 
@@ -101,6 +103,25 @@ public class LFWLoader extends BaseImageLoader implements Serializable {
 
     public LFWLoader(){this(false);}
 
+    @Override
+    public INDArray asRowVector(File f) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public INDArray asRowVector(InputStream inputStream) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public INDArray asMatrix(File f) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public INDArray asMatrix(InputStream inputStream) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 
     public void generateLfwMaps() {
         if(useSubset) {

--- a/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/loader/NativeImageLoader.java
+++ b/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/loader/NativeImageLoader.java
@@ -1,0 +1,200 @@
+/*
+ *
+ *  *
+ *  *  * Copyright 2016 Skymind,Inc.
+ *  *  *
+ *  *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *    you may not use this file except in compliance with the License.
+ *  *  *    You may obtain a copy of the License at
+ *  *  *
+ *  *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *  *
+ *  *  *    Unless required by applicable law or agreed to in writing, software
+ *  *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *    See the License for the specific language governing permissions and
+ *  *  *    limitations under the License.
+ *  *
+ *
+ */
+package org.canova.image.loader;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.commons.io.IOUtils;
+import org.bytedeco.javacpp.indexer.UByteIndexer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+import static org.bytedeco.javacpp.opencv_core.*;
+import static org.bytedeco.javacpp.opencv_imgcodecs.*;
+import static org.bytedeco.javacpp.opencv_imgproc.*;
+
+/**
+ * Uses JavaCV to load images.
+ *
+ * @author saudet
+ */
+public class NativeImageLoader extends BaseImageLoader {
+
+    public NativeImageLoader() {
+    }
+
+    /**
+     * Instantiate an image with the given
+     * height and width
+     * @param height the height to load*
+     * @param width  the width to load
+
+     */
+    public NativeImageLoader(int height,int width) {
+        this.height = height;
+        this.width = width;
+    }
+
+
+    /**
+     * Instantiate an image with the given
+     * height and width
+     * @param height the height to load
+     * @param width  the width to load
+     * @param channels the number of channels for the image*
+     */
+    public NativeImageLoader(int height, int width, int channels) {
+        this.height = height;
+        this.width = width;
+        this.channels = channels;
+    }
+
+    public NativeImageLoader(int height, int width, int channels, boolean centerCropIfNeeded) {
+        this(height, width, channels);
+        this.centerCropIfNeeded = centerCropIfNeeded;
+    }
+
+    /**
+     * Convert a file to a row vector
+     *
+     * @param f the image to convert
+     * @return the flattened image
+     * @throws IOException
+     */
+    @Override
+    public INDArray asRowVector(File f) throws IOException {
+        return asMatrix(f).ravel();
+    }
+
+    @Override
+    public INDArray asRowVector(InputStream is) throws IOException {
+        return asMatrix(is).ravel();
+    }
+
+    public INDArray asRowVector(Mat image) throws IOException {
+        return asMatrix(image).ravel();
+    }
+
+    @Override
+    public INDArray asMatrix(File f) throws IOException {
+        Mat image = imread(f.getAbsolutePath(), channels == 1 ? CV_LOAD_IMAGE_GRAYSCALE
+                : channels == 3 ? CV_LOAD_IMAGE_COLOR : CV_LOAD_IMAGE_UNCHANGED);
+        if (image == null) {
+            throw new IOException("Could not read image from file: " + f);
+        }
+        return asMatrix(image);
+    }
+
+    @Override
+    public INDArray asMatrix(InputStream is) throws IOException {
+        byte[] bytes = IOUtils.toByteArray(is);
+        Mat image = imdecode(new Mat(bytes), channels == 1 ? CV_LOAD_IMAGE_GRAYSCALE
+                : channels == 3 ? CV_LOAD_IMAGE_COLOR : CV_LOAD_IMAGE_UNCHANGED);
+        if (image == null) {
+            throw new IOException("Could not decode image from input stream");
+        }
+        return asMatrix(image);
+    }
+
+    public INDArray asMatrix(Mat image) throws IOException {
+        if (channels > 0 && image.channels() != channels) {
+            int code = -1;
+            switch (image.channels()) {
+                case 1:
+                    switch (channels) {
+                        case 3: code = CV_GRAY2BGR; break;
+                        case 4: code = CV_GRAY2RGBA; break;
+                    }
+                    break;
+                case 3:
+                    switch (channels) {
+                        case 1: code = CV_BGR2GRAY; break;
+                        case 4: code = CV_BGR2RGBA; break;
+                    }
+                    break;
+                case 4:
+                    switch (channels) {
+                        case 1: code = CV_RGBA2GRAY; break;
+                        case 3: code = CV_RGBA2BGR; break;
+                    }
+                    break;
+            }
+            if (code < 0) {
+                throw new IOException("Cannot convert from " + image.channels()
+                                                    + " to " + channels + " channels.");
+            }
+            Mat newimage = new Mat();
+            cvtColor(image, newimage, code);
+            image = newimage;
+        }
+        if (centerCropIfNeeded) {
+            image = centerCropIfNeeded(image);
+        }
+        image = scalingIfNeed(image);
+        int rows = image.rows();
+        int cols = image.cols();
+        int channels = image.channels();
+        UByteIndexer idx = image.createIndexer();
+        INDArray ret = channels > 1 ? Nd4j.create(channels, rows, cols) : Nd4j.create(rows, cols);
+        for (int k = 0; k < channels; k++) {
+            for (int i = 0; i < rows; i++) {
+                for (int j = 0; j < cols; j++) {
+                    if (channels > 1) {
+                        ret.putScalar(k, i, j, idx.get(i, j, k));
+                    } else {
+                        ret.putScalar(i, j, idx.get(i, j));
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    // TODO build flexibility on where to crop the image
+    protected Mat centerCropIfNeeded(Mat img) {
+        int x = 0;
+        int y = 0;
+        int height = img.rows();
+        int width = img.cols();
+        int diff = Math.abs(width - height) / 2;
+
+        if (width > height) {
+            x = diff;
+            width = width - diff;
+        } else if (height > width) {
+            y = diff;
+            height = height - diff;
+        }
+        return img.apply(new Rect(x, y, width, height));
+    }
+
+    protected Mat scalingIfNeed(Mat image) {
+        return scalingIfNeed(image, height, width);
+    }
+
+    protected Mat scalingIfNeed(Mat image, int dstHeight, int dstWidth) {
+        Mat scaled = image;
+        if (dstHeight > 0 && dstWidth > 0 && (image.rows() != dstHeight || image.cols() != dstWidth)) {
+            resize(image, scaled = new Mat(), new Size(dstWidth, dstHeight));
+        }
+        return scaled;
+    }
+}

--- a/canova-nd4j/canova-nd4j-image/src/test/java/org/canova/image/loader/TestNativeImageLoader.java
+++ b/canova-nd4j/canova-nd4j-image/src/test/java/org/canova/image/loader/TestNativeImageLoader.java
@@ -1,0 +1,175 @@
+/*
+ *
+ *  *
+ *  *  * Copyright 2016 Skymind,Inc.
+ *  *  *
+ *  *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *    you may not use this file except in compliance with the License.
+ *  *  *    You may obtain a copy of the License at
+ *  *  *
+ *  *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *  *
+ *  *  *    Unless required by applicable law or agreed to in writing, software
+ *  *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *    See the License for the specific language governing permissions and
+ *  *  *    limitations under the License.
+ *  *
+ *
+ */
+package org.canova.image.loader;
+
+import java.util.Random;
+import org.bytedeco.javacpp.indexer.UByteIndexer;
+import org.junit.Test;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import static org.junit.Assert.assertEquals;
+import static org.bytedeco.javacpp.opencv_core.*;
+
+/**
+ *
+ * @author saudet
+ */
+public class TestNativeImageLoader {
+    static final long seed = 10;
+    static final Random rng = new Random(seed);
+
+    @Test
+    public void testAsRowVector() throws Exception {
+        Mat img1 = makeRandomImage(0, 0, 1);
+        Mat img2 = makeRandomImage(0, 0, 3);
+
+        int w1 = 35, h1 = 79, ch1 = 3;
+        NativeImageLoader loader1 = new NativeImageLoader(h1, w1, ch1);
+
+        INDArray array1 = loader1.asRowVector(img1);
+        assertEquals(2, array1.rank());
+        assertEquals(1, array1.rows());
+        assertEquals(h1 * w1 * ch1, array1.columns());
+
+        INDArray array2 = loader1.asRowVector(img2);
+        assertEquals(2, array2.rank());
+        assertEquals(1, array2.rows());
+        assertEquals(h1 * w1 * ch1, array2.columns());
+
+        int w2 = 103, h2 = 68, ch2 = 4;
+        NativeImageLoader loader2 = new NativeImageLoader(h2, w2, ch2);
+
+        INDArray array3 = loader2.asRowVector(img1);
+        assertEquals(2, array3.rank());
+        assertEquals(1, array3.rows());
+        assertEquals(h2 * w2 * ch2, array3.columns());
+
+        INDArray array4 = loader2.asRowVector(img2);
+        assertEquals(2, array4.rank());
+        assertEquals(1, array4.rows());
+        assertEquals(h2 * w2 * ch2, array4.columns());
+    }
+
+    @Test
+    public void testAsMatrix() throws Exception {
+        Mat img1 = makeRandomImage(0, 0, 3);
+        Mat img2 = makeRandomImage(0, 0, 4);
+
+        int w1 = 33, h1 = 77, ch1 = 1;
+        NativeImageLoader loader1 = new NativeImageLoader(h1, w1, ch1);
+
+        INDArray array1 = loader1.asMatrix(img1);
+        assertEquals(2, array1.rank());
+        assertEquals(h1, array1.rows());
+        assertEquals(w1, array1.columns());
+
+        INDArray array2 = loader1.asMatrix(img2);
+        assertEquals(2, array2.rank());
+        assertEquals(h1, array2.rows());
+        assertEquals(w1, array2.columns());
+
+        int w2 = 111, h2 = 66, ch2 = 3;
+        NativeImageLoader loader2 = new NativeImageLoader(h2, w2, ch2);
+
+        INDArray array3 = loader2.asMatrix(img1);
+        assertEquals(3, array3.rank());
+        assertEquals(3, array3.size(0));
+        assertEquals(h2, array3.size(1));
+        assertEquals(w2, array3.size(2));
+
+        INDArray array4 = loader2.asMatrix(img2);
+        assertEquals(3, array4.rank());
+        assertEquals(3, array4.size(0));
+        assertEquals(h2, array4.size(1));
+        assertEquals(w2, array4.size(2));
+    }
+
+    @Test
+    public void testScalingIfNeed() throws Exception {
+        Mat img1 = makeRandomImage(0, 0, 1);
+        Mat img2 = makeRandomImage(0, 0, 3);
+
+        int w1 = 60, h1 = 110, ch1 = 1;
+        NativeImageLoader loader1 = new NativeImageLoader(h1, w1, ch1);
+
+        Mat scaled1 = loader1.scalingIfNeed(img1);
+        assertEquals(h1, scaled1.rows());
+        assertEquals(w1, scaled1.cols());
+        assertEquals(img1.channels(), scaled1.channels());
+
+        Mat scaled2 = loader1.scalingIfNeed(img2);
+        assertEquals(h1, scaled2.rows());
+        assertEquals(w1, scaled2.cols());
+        assertEquals(img2.channels(), scaled2.channels());
+
+        int w2 = 70, h2 = 120, ch2 = 3;
+        NativeImageLoader loader2 = new NativeImageLoader(h2, w2, ch2);
+
+        Mat scaled3 = loader2.scalingIfNeed(img1);
+        assertEquals(h2, scaled3.rows());
+        assertEquals(w2, scaled3.cols());
+        assertEquals(img1.channels(), scaled3.channels());
+
+        Mat scaled4 = loader2.scalingIfNeed(img2);
+        assertEquals(h2, scaled4.rows());
+        assertEquals(w2, scaled4.cols());
+        assertEquals(img2.channels(), scaled4.channels());
+    }
+
+    @Test
+    public void testCenterCropIfNeeded() throws Exception {
+        int w1 = 60, h1 = 110, ch1 = 1;
+        int w2 = 120, h2 = 70, ch2 = 3;
+
+        Mat img1 = makeRandomImage(h1, w1, ch1);
+        Mat img2 = makeRandomImage(h2, w2, ch2);
+
+        NativeImageLoader loader = new NativeImageLoader(h1, w1, ch1, true);
+
+        Mat cropped1 = loader.centerCropIfNeeded(img1);
+        assertEquals(85, cropped1.rows());
+        assertEquals(60, cropped1.cols());
+        assertEquals(img1.channels(), cropped1.channels());
+
+        Mat cropped2 = loader.centerCropIfNeeded(img2);
+        assertEquals(70, cropped2.rows());
+        assertEquals(95, cropped2.cols());
+        assertEquals(img2.channels(), cropped2.channels());
+    }
+
+    Mat makeRandomImage(int height, int width, int channels) {
+        if (height <= 0) {
+            height = rng.nextInt() % 100 + 100;
+        }
+        if (width <= 0) {
+            width = rng.nextInt() % 100 + 100;
+        }
+        Mat img = new Mat(height, width, CV_8UC(channels));
+        UByteIndexer idx = img.createIndexer();
+        for (int i = 0; i < height; i++) {
+            for (int j = 0; j < width; j++) {
+                for (int k = 0; k < channels; k++) {
+                    idx.put(i, j, k, rng.nextInt());
+                }
+            }
+        }
+        return img;
+    }
+}


### PR DESCRIPTION
- Make BaseImageLoader abstract and use it inside BaseImageRecordReader and VideoRecordReader
- Eliminate ImageIO dependency from BaseImageRecordReader and ImageNetRecordReader
- Fix ImageLoader.centerCropIfNeeded() not returning square images

Support for more features listed in issue #135.