### PR TITLE
Bump default Scala to 2.11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,8 @@
         <commons-math3.version>3.3</commons-math3.version>
         <commons-io.version>2.4</commons-io.version>
         <args4j.version>2.0.29</args4j.version>
-        <scala.binary.version>2.10</scala.binary.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <scala.version>2.11.7</scala.binary.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
Deeplearning4j is now default building to `2.11`. Best we match it.