### PR TITLE
Fix not parsable pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <commons-io.version>2.4</commons-io.version>
         <args4j.version>2.0.29</args4j.version>
         <scala.binary.version>2.11</scala.binary.version>
-        <scala.version>2.11.7</scala.binary.version>
+        <scala.version>2.11.7</scala.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
Mvn shouted error due to wrong pom.xml syntax.
This is the fix.