### PR TITLE
Introduce RecordListener to facilitate debugging and visualization

### DIFF
--- a/canova-api/src/main/java/org/canova/api/records/listener/RecordListener.java
+++ b/canova-api/src/main/java/org/canova/api/records/listener/RecordListener.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *  * Copyright 2016 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+package org.canova.api.records.listener;
+
+import java.io.Serializable;
+import org.canova.api.records.reader.RecordReader;
+import org.canova.api.records.writer.RecordWriter;
+
+/**
+ * Each time a record is read or written, mainly used for debugging or visualization.
+ *
+ * @author saudet
+ */
+public interface RecordListener extends Serializable {
+    /**
+     * Get if listener invoked.
+     */
+    boolean invoked();
+
+    /**
+     * Change invoke to true.
+     */
+    void invoke();
+
+    /**
+     * Event listener for each record to be read.
+     * @param reader the record reader
+     * @param record in raw format (Collection, File, String, Writable, etc)
+     */
+    void recordRead(RecordReader reader, Object record);
+
+    /**
+     * Event listener for each record to be written.
+     * @param writer the record writer
+     * @param record in raw format (Collection, File, String, Writable, etc)
+     */
+    void recordWrite(RecordWriter writer, Object record);
+}

--- a/canova-api/src/main/java/org/canova/api/records/listener/impl/LogRecordListener.java
+++ b/canova-api/src/main/java/org/canova/api/records/listener/impl/LogRecordListener.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  * Copyright 2016 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+package org.canova.api.records.listener.impl;
+
+import org.canova.api.records.listener.RecordListener;
+import org.canova.api.records.reader.RecordReader;
+import org.canova.api.records.writer.RecordWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A record listener that logs every record to be read or written.
+ *
+ * @author saudet
+ */
+public class LogRecordListener implements RecordListener {
+    private static final Logger log = LoggerFactory.getLogger(LogRecordListener.class);
+    private boolean invoked = false;
+
+    @Override
+    public boolean invoked(){ return invoked; }
+
+    @Override
+    public void invoke() { this.invoked = true; }
+
+    @Override
+    public void recordRead(RecordReader reader, Object record) {
+        invoke();
+        log.info("Reading " + record);
+    }
+
+    @Override
+    public void recordWrite(RecordWriter writer, Object record) {
+        invoke();
+        log.info("Writing " + record);
+    }
+}

--- a/canova-api/src/main/java/org/canova/api/records/reader/BaseRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/BaseRecordReader.java
@@ -1,0 +1,57 @@
+/*
+ *
+ *  * Copyright 2016 Skymind,Inc.
+ *  *
+ *  *    Licensed under the Apache License, Version 2.0 (the "License");
+ *  *    you may not use this file except in compliance with the License.
+ *  *    You may obtain a copy of the License at
+ *  *
+ *  *        http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *    Unless required by applicable law or agreed to in writing, software
+ *  *    distributed under the License is distributed on an "AS IS" BASIS,
+ *  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *    See the License for the specific language governing permissions and
+ *  *    limitations under the License.
+ *
+ */
+package org.canova.api.records.reader;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import org.canova.api.records.listener.RecordListener;
+
+/**
+ * Manages record listeners.
+ *
+ * @author saudet
+ */
+public abstract class BaseRecordReader implements RecordReader {
+
+    protected Collection<RecordListener> listeners = new ArrayList<>();
+
+    /** Invokes {@link RecordListener#recordRead(RecordReader, Object)} on all listeners. */
+    protected void invokeListeners(Object record) {
+        for(RecordListener listener : listeners) {
+            listener.recordRead(this, record);
+        }
+    }
+
+    @Override
+    public Collection<RecordListener> getListeners() {
+        return listeners;
+    }
+
+    @Override
+    public void setListeners(Collection<RecordListener> listeners) {
+        this.listeners = listeners;
+    }
+
+    @Override
+    public void setListeners(RecordListener... listeners) {
+        Collection<RecordListener> cListeners = new ArrayList<>();
+        Collections.addAll(cListeners, listeners);
+        setListeners(cListeners);
+    }
+}

--- a/canova-api/src/main/java/org/canova/api/records/reader/RecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/RecordReader.java
@@ -22,6 +22,7 @@ package org.canova.api.records.reader;
 
 import org.canova.api.conf.Configurable;
 import org.canova.api.conf.Configuration;
+import org.canova.api.records.listener.RecordListener;
 import org.canova.api.split.InputSplit;
 import org.canova.api.writable.Writable;
 
@@ -94,4 +95,17 @@ public interface RecordReader extends Closeable,Serializable,Configurable {
      */
     Collection<Writable> record(URI uri, DataInputStream dataInputStream) throws IOException;
 
+    /**
+     * Get the record listeners for this record reader.
+     */
+    Collection<RecordListener> getListeners();
+
+    /**
+     * Set the record listeners for this record reader.
+     */
+    void setListeners(RecordListener...listeners);
+    /**
+     * Set the record listeners for this record reader.
+     */
+    void setListeners(Collection<RecordListener> listeners);
 }

--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/CSVSequenceRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/CSVSequenceRecordReader.java
@@ -38,6 +38,7 @@ public class CSVSequenceRecordReader extends FileRecordReader implements Sequenc
 
     @Override
     public Collection<Collection<Writable>> sequenceRecord(URI uri, DataInputStream dataInputStream) throws IOException {
+        invokeListeners(uri);
         @SuppressWarnings("unchecked")
         Iterator<String> lineIter = IOUtils.lineIterator(new InputStreamReader(dataInputStream));
         if (skipNumLines > 0) {
@@ -61,6 +62,7 @@ public class CSVSequenceRecordReader extends FileRecordReader implements Sequenc
     @SuppressWarnings("unchecked")
     public Collection<Collection<Writable>> sequenceRecord() {
         File next = iter.next();
+        invokeListeners(next);
 
         Iterator<String> lineIter;
         try {

--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/CollectionRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/CollectionRecordReader.java
@@ -22,7 +22,7 @@ package org.canova.api.records.reader.impl;
 
 
 import org.canova.api.conf.Configuration;
-import org.canova.api.records.reader.RecordReader;
+import org.canova.api.records.reader.BaseRecordReader;
 import org.canova.api.split.InputSplit;
 import org.canova.api.writable.Writable;
 
@@ -40,7 +40,7 @@ import java.util.Map;
  *
  * @author Adam Gibson
  */
-public class CollectionRecordReader implements RecordReader {
+public class CollectionRecordReader extends BaseRecordReader {
     private Iterator<? extends Collection<Writable>> records;
     private final Collection<? extends Collection<Writable>> original;
 
@@ -61,7 +61,9 @@ public class CollectionRecordReader implements RecordReader {
 
     @Override
     public Collection<Writable> next() {
-        return records.next();
+        Collection<Writable> record = records.next();
+        invokeListeners(record);
+        return record;
     }
 
     @Override

--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/CollectionSequenceRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/CollectionSequenceRecordReader.java
@@ -22,7 +22,7 @@ package org.canova.api.records.reader.impl;
 
 
 import org.canova.api.conf.Configuration;
-import org.canova.api.records.reader.RecordReader;
+import org.canova.api.records.reader.BaseRecordReader;
 import org.canova.api.records.reader.SequenceRecordReader;
 import org.canova.api.split.InputSplit;
 import org.canova.api.writable.Writable;
@@ -40,7 +40,7 @@ import java.util.List;
  *
  * @author Alex Black
  */
-public class CollectionSequenceRecordReader implements SequenceRecordReader {
+public class CollectionSequenceRecordReader extends BaseRecordReader implements SequenceRecordReader {
     private Iterator<? extends Collection<? extends Collection<Writable>>> records;
     private final Collection<? extends Collection<? extends Collection<Writable>>> original;
 
@@ -108,7 +108,9 @@ public class CollectionSequenceRecordReader implements SequenceRecordReader {
     @Override
     @SuppressWarnings("unchecked")
     public Collection<Collection<Writable>> sequenceRecord() {
-        return (Collection<Collection<Writable>>) records.next();
+        Collection<Collection<Writable>> record = (Collection<Collection<Writable>>)records.next();
+        invokeListeners(record);
+        return record;
     }
 
     @Override

--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/ComposableRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/ComposableRecordReader.java
@@ -21,6 +21,7 @@
 package org.canova.api.records.reader.impl;
 
 import org.canova.api.conf.Configuration;
+import org.canova.api.records.reader.BaseRecordReader;
 import org.canova.api.records.reader.RecordReader;
 import org.canova.api.split.InputSplit;
 import org.canova.api.writable.Writable;
@@ -40,7 +41,7 @@ RecordReader for each pipeline. Individual record is a concatenation of the two 
         concatenation would be next & addAll on the collection
         return one record
  */
-public class ComposableRecordReader implements RecordReader {
+public class ComposableRecordReader extends BaseRecordReader {
 
     private RecordReader[] readers;
 
@@ -66,6 +67,7 @@ public class ComposableRecordReader implements RecordReader {
                 ret.addAll(reader.next());
             }
         }
+        invokeListeners(ret);
         return ret;
     }
 

--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/FileRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/FileRecordReader.java
@@ -24,7 +24,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.canova.api.conf.Configuration;
 import org.canova.api.io.data.Text;
-import org.canova.api.records.reader.RecordReader;
+import org.canova.api.records.reader.BaseRecordReader;
 import org.canova.api.split.InputSplit;
 import org.canova.api.writable.Writable;
 
@@ -38,7 +38,7 @@ import java.util.*;
  *
  * @author Adam Gibson
  */
-public class FileRecordReader implements RecordReader {
+public class FileRecordReader extends BaseRecordReader {
 
     protected Iterator<File> iter;
     protected Configuration conf;
@@ -112,6 +112,7 @@ public class FileRecordReader implements RecordReader {
         try {
             File next = iter.next();
             this.currentFile = next;
+            invokeListeners(next);
             ret.add(new Text(FileUtils.readFileToString(next)));
         } catch (IOException e) {
             e.printStackTrace();
@@ -124,6 +125,7 @@ public class FileRecordReader implements RecordReader {
                 try {
                     File next = iter.next();
                     this.currentFile = next;
+                    invokeListeners(next);
                     ret.add(new Text(FileUtils.readFileToString(next)));
                 } catch (IOException e) {
                     e.printStackTrace();
@@ -185,6 +187,7 @@ public class FileRecordReader implements RecordReader {
 
     @Override
     public Collection<Writable> record(URI uri, DataInputStream dataInputStream) throws IOException {
+        invokeListeners(uri);
         //Here: reading the entire file to a Text writable
         BufferedReader br = new BufferedReader(new InputStreamReader(dataInputStream));
         StringBuilder sb = new StringBuilder();

--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/LineRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/LineRecordReader.java
@@ -24,7 +24,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.canova.api.conf.Configuration;
 import org.canova.api.io.data.Text;
-import org.canova.api.records.reader.RecordReader;
+import org.canova.api.records.reader.BaseRecordReader;
 import org.canova.api.split.FileSplit;
 import org.canova.api.split.InputSplit;
 import org.canova.api.split.InputStreamInputSplit;
@@ -40,7 +40,7 @@ import java.util.*;
  *
  * @author Adam Gibson
  */
-public class LineRecordReader implements RecordReader {
+public class LineRecordReader extends BaseRecordReader {
 
 
     private Iterator<String> iter;
@@ -78,7 +78,9 @@ public class LineRecordReader implements RecordReader {
         List<Writable> ret = new ArrayList<>();
 
         if(iter.hasNext()) {
-            ret.add(new Text(iter.next()));
+            String record = iter.next();
+            invokeListeners(record);
+            ret.add(new Text(record));
             return ret;
         } else {
             if ( !(inputSplit instanceof StringSplit) && currIndex < locations.length-1 ) {
@@ -91,7 +93,9 @@ public class LineRecordReader implements RecordReader {
                 }
 
                 if(iter.hasNext()) {
-                    ret.add(new Text(iter.next()));
+                    String record = iter.next();
+                    invokeListeners(record);
+                    ret.add(new Text(record));
                     return ret;
                 }
             }
@@ -157,6 +161,7 @@ public class LineRecordReader implements RecordReader {
 
     @Override
     public Collection<Writable> record(URI uri, DataInputStream dataInputStream) throws IOException {
+        invokeListeners(uri);
         //Here: we are reading a single line from the DataInputStream
         BufferedReader br = new BufferedReader(new InputStreamReader(dataInputStream));
         String line = br.readLine();

--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/ListStringRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/ListStringRecordReader.java
@@ -2,7 +2,7 @@ package org.canova.api.records.reader.impl;
 
 import org.canova.api.conf.Configuration;
 import org.canova.api.io.data.Text;
-import org.canova.api.records.reader.RecordReader;
+import org.canova.api.records.reader.BaseRecordReader;
 import org.canova.api.split.InputSplit;
 import org.canova.api.split.ListStringSplit;
 import org.canova.api.writable.Writable;
@@ -21,7 +21,7 @@ import java.util.List;
  *
  * @author Adam Gibson
  */
-public class ListStringRecordReader implements RecordReader {
+public class ListStringRecordReader extends BaseRecordReader {
     private List<List<String>> delimitedData;
     private Iterator<List<String>> dataIter;
     private Configuration conf;
@@ -65,6 +65,7 @@ public class ListStringRecordReader implements RecordReader {
     @Override
     public Collection<Writable> next() {
         List<String> next = dataIter.next();
+        invokeListeners(next);
         List<Writable> ret = new ArrayList<>();
         for(String s : next)
             ret.add(new Text(s));

--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/jackson/JacksonRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/jackson/JacksonRecordReader.java
@@ -6,7 +6,7 @@ import org.apache.commons.io.FileUtils;
 import org.canova.api.conf.Configuration;
 import org.canova.api.io.data.Text;
 import org.canova.api.io.labels.PathLabelGenerator;
-import org.canova.api.records.reader.RecordReader;
+import org.canova.api.records.reader.BaseRecordReader;
 import org.canova.api.split.FileSplit;
 import org.canova.api.split.InputSplit;
 import org.canova.api.writable.Writable;
@@ -38,7 +38,7 @@ import java.util.*;
  *
  * @author Alex Black
  */
-public class JacksonRecordReader implements RecordReader {
+public class JacksonRecordReader extends BaseRecordReader {
 
     private static final TypeReference<Map<String,Object>> typeRef = new TypeReference<Map<String, Object>>(){};
 
@@ -100,6 +100,7 @@ public class JacksonRecordReader implements RecordReader {
         if(!hasNext()) throw new NoSuchElementException("No next element");
 
         URI uri = uris[cursor++];
+        invokeListeners(uri);
         String fileAsString;
         try{
             fileAsString = FileUtils.readFileToString(new File(uri.toURL().getFile()));

--- a/canova-data/canova-data-audio/src/main/java/org/canova/sound/recordreader/WavFileRecordReader.java
+++ b/canova-data/canova-data-audio/src/main/java/org/canova/sound/recordreader/WavFileRecordReader.java
@@ -23,7 +23,7 @@ package org.canova.sound.recordreader;
 import org.apache.commons.io.FileUtils;
 import org.canova.api.conf.Configuration;
 import org.canova.api.io.data.DoubleWritable;
-import org.canova.api.records.reader.RecordReader;
+import org.canova.api.records.reader.BaseRecordReader;
 import org.canova.api.split.FileSplit;
 import org.canova.api.split.InputSplit;
 import org.canova.api.split.InputStreamInputSplit;
@@ -44,7 +44,7 @@ import java.util.*;
  * Wav file loader
  * @author Adam Gibson
  */
-public class WavFileRecordReader implements RecordReader {
+public class WavFileRecordReader extends BaseRecordReader {
     private Iterator<File> iter;
     private Collection<Writable> record;
     private boolean hitImage = false;
@@ -130,6 +130,7 @@ public class WavFileRecordReader implements RecordReader {
     public Collection<Writable> next() {
         if(iter != null) {
             File next = iter.next();
+            invokeListeners(next);
             Wave wave = new Wave(next.getAbsolutePath());
             return RecordUtils.toRecord(wave.getNormalizedAmplitudes());
         }
@@ -186,6 +187,7 @@ public class WavFileRecordReader implements RecordReader {
 
     @Override
     public Collection<Writable> record(URI uri, DataInputStream dataInputStream) throws IOException {
+        invokeListeners(uri);
         Wave wave = new Wave(dataInputStream);
         return RecordUtils.toRecord(wave.getNormalizedAmplitudes());
     }

--- a/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/recordreader/BaseImageRecordReader.java
+++ b/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/recordreader/BaseImageRecordReader.java
@@ -24,7 +24,7 @@ import org.apache.commons.io.FileUtils;
 import org.canova.api.conf.Configuration;
 import org.canova.api.io.data.DoubleWritable;
 import org.canova.api.io.labels.PathLabelGenerator;
-import org.canova.api.records.reader.RecordReader;
+import org.canova.api.records.reader.BaseRecordReader;
 import org.canova.api.split.FileSplit;
 import org.canova.api.split.InputSplit;
 import org.canova.api.writable.Writable;
@@ -46,7 +46,7 @@ import java.util.*;
  *
  * @author Adam Gibson
  */
-public abstract class BaseImageRecordReader implements RecordReader {
+public abstract class BaseImageRecordReader extends BaseRecordReader {
     protected Iterator<File> iter;
     protected Configuration conf;
     protected File currentFile;
@@ -232,6 +232,7 @@ public abstract class BaseImageRecordReader implements RecordReader {
             if (image.isDirectory())
                 return next();
             try {
+                invokeListeners(image);
                 INDArray row = imageLoader.asRowVector(image);
                 ret = RecordConverter.toRecord(row);
                 if (appendLabel)
@@ -242,6 +243,7 @@ public abstract class BaseImageRecordReader implements RecordReader {
             return ret;
         } else if (record != null) {
             hitImage = true;
+            invokeListeners(record);
             return record;
         }
         throw new IllegalStateException("No more elements");
@@ -336,6 +338,7 @@ public abstract class BaseImageRecordReader implements RecordReader {
 
     @Override
     public Collection<Writable> record(URI uri, DataInputStream dataInputStream) throws IOException {
+        invokeListeners(uri);
         if (imageLoader == null) {
             imageLoader = new NativeImageLoader(height, width, channels, imageTransform);
         }

--- a/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/recordreader/ImageNetRecordReader.java
+++ b/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/recordreader/ImageNetRecordReader.java
@@ -138,6 +138,7 @@ public class ImageNetRecordReader extends BaseImageRecordReader {
                 return next();
 
             try {
+                invokeListeners(image);
                 return load(imageLoader.asRowVector(image), image.getName());
             } catch (Exception e) {
                 e.printStackTrace();
@@ -150,7 +151,9 @@ public class ImageNetRecordReader extends BaseImageRecordReader {
             else {
                 if(iter.hasNext()) {
                     try {
-                        ret.add(new Text(FileUtils.readFileToString((File) iter.next())));
+                        image = iter.next();
+                        invokeListeners(image);
+                        ret.add(new Text(FileUtils.readFileToString(image)));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -160,6 +163,7 @@ public class ImageNetRecordReader extends BaseImageRecordReader {
         }
         else if(record != null) {
             hitImage = true;
+            invokeListeners(record);
             return record;
         }
         throw new IllegalStateException("No more elements");
@@ -184,6 +188,7 @@ public class ImageNetRecordReader extends BaseImageRecordReader {
 
     @Override
     public Collection<Writable> record(URI uri, DataInputStream dataInputStream ) throws IOException {
+        invokeListeners(uri);
         imgNetLabelSetup();
         return load(imageLoader.asRowVector(dataInputStream), FilenameUtils.getName(uri.getPath()));
     }

--- a/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/recordreader/MNISTRecordReader.java
+++ b/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/recordreader/MNISTRecordReader.java
@@ -5,7 +5,7 @@ import org.canova.api.split.InputSplit;
 import org.apache.commons.io.IOUtils;
 import org.canova.api.conf.Configuration;
 
-import org.canova.api.records.reader.RecordReader;
+import org.canova.api.records.reader.BaseRecordReader;
 
 import org.nd4j.linalg.factory.Nd4j;
 
@@ -55,7 +55,7 @@ import java.util.*;
  * @author Josh Patterson
  *
  */
-public class MNISTRecordReader implements RecordReader {
+public class MNISTRecordReader extends BaseRecordReader {
 
 	private static Logger log = LoggerFactory.getLogger(MNISTRecordReader.class);
 
@@ -160,6 +160,7 @@ public class MNISTRecordReader implements RecordReader {
     	}
     	
     	DataSet currentRecord = this.curr;
+        invokeListeners(currentRecord);
     	
         List<Writable> ret = new ArrayList<>();
         //try {

--- a/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/recordreader/VideoRecordReader.java
+++ b/canova-nd4j/canova-nd4j-image/src/main/java/org/canova/image/recordreader/VideoRecordReader.java
@@ -24,6 +24,7 @@ import org.apache.commons.io.FileUtils;
 import org.canova.api.conf.Configuration;
 import org.canova.api.io.data.DoubleWritable;
 import org.canova.api.io.data.Text;
+import org.canova.api.records.reader.BaseRecordReader;
 import org.canova.api.records.reader.SequenceRecordReader;
 import org.canova.api.split.FileSplit;
 import org.canova.api.split.InputSplit;
@@ -53,7 +54,7 @@ import java.util.*;
  * @author Adam Gibson
  *
  */
-public class VideoRecordReader implements SequenceRecordReader {
+public class VideoRecordReader extends BaseRecordReader implements SequenceRecordReader {
     private Iterator<File> iter;
     private int height = 28, width = 28;
     private BaseImageLoader imageLoader;
@@ -214,6 +215,7 @@ public class VideoRecordReader implements SequenceRecordReader {
             if(image.isDirectory() || !containsFormat(image.getAbsolutePath()))
                 return next();
             try {
+                invokeListeners(image);
                 INDArray row = imageLoader.asRowVector(image);
                 for(int i = 0; i < row.length(); i++)
                     ret.add(new DoubleWritable(row.getDouble(i)));
@@ -241,6 +243,7 @@ public class VideoRecordReader implements SequenceRecordReader {
 
         else if(record != null) {
             hitImage = true;
+            invokeListeners(record);
             return record;
         }
 
@@ -268,6 +271,7 @@ public class VideoRecordReader implements SequenceRecordReader {
     @Override
     public Collection<Collection<Writable>> sequenceRecord() {
         File next = iter.next();
+        invokeListeners(next);
         if(!next.isDirectory())
             return Collections.emptyList();
         File[] list = next.listFiles();


### PR DESCRIPTION
I think one of the main challenges people have with using a RecordReader is understanding what is going on in the process. For things like CSV files, that can happen at a later stage when everything is in memory, but for images, they get loaded on demand. With these changes, and after adding a listener the following way, we get to see which images are actually used for each iteration:
```java
recordReader.setListeners(new LogRecordListener());
```

In the case of MSRA_CFW, the log looks something like this:
```
18:49:18.822 [main] INFO  o.c.a.r.l.impl.LogRecordListener - Reading /home/saudet/thumbnails_features_deduped_sample/aaron carter/17.jpg
18:49:19.252 [main] INFO  o.c.a.r.l.impl.LogRecordListener - Reading /home/saudet/thumbnails_features_deduped_sample/steve jobs/10.jpg
...
18:49:27.378 [main] INFO  o.d.o.l.ScoreIterationListener - Score at iteration 0 is 100.55098394861483
18:49:27.387 [main] INFO  o.c.a.r.l.impl.LogRecordListener - Reading /home/saudet/thumbnails_features_deduped_sample/al gore/101.jpg
18:49:27.436 [main] INFO  o.c.a.r.l.impl.LogRecordListener - Reading /home/saudet/thumbnails_features_deduped_sample/martina hingis/10.jpg
...
18:49:34.868 [main] INFO  o.d.o.l.ScoreIterationListener - Score at iteration 1 is 99.37281817688553
18:49:34.879 [main] INFO  o.c.a.r.l.impl.LogRecordListener - Reading /home/saudet/thumbnails_features_deduped_sample/aaron carter/17.jpg
18:49:34.920 [main] INFO  o.c.a.r.l.impl.LogRecordListener - Reading /home/saudet/thumbnails_features_deduped_sample/steve jobs/10.jpg
...
```

While for the ImagePipelineExample (https://github.com/deeplearning4j/dl4j-0.4-examples/pull/158), we get to know which file is currently displayed in the window:
```
o.c.a.r.l.i.LogRecordListener - Reading /home/saudet/projects/skymind/dl4j-0.4-examples/src/main/resources/DataExamples/ImagePipeline/labelC/image_0411.jpg
o.c.a.r.l.i.LogRecordListener - Reading /home/saudet/projects/skymind/dl4j-0.4-examples/src/main/resources/DataExamples/ImagePipeline/labelB/image_0114.jpg
o.c.a.r.l.i.LogRecordListener - Reading /home/saudet/projects/skymind/dl4j-0.4-examples/src/main/resources/DataExamples/ImagePipeline/labelA/image_0017.jpg
...
```

If this sounds like something we want, please merge!