### PR TITLE
fix reset in LineRecordReader

### DIFF
--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/LineRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/LineRecordReader.java
@@ -154,6 +154,7 @@ public class LineRecordReader extends BaseRecordReader {
         if(inputSplit == null) throw new UnsupportedOperationException("Cannot reset without first initializing");
         try{
             initialize(inputSplit);
+            currIndex = 0;
         }catch(Exception e){
             throw new RuntimeException("Error during LineRecordReader reset",e);
         }


### PR DESCRIPTION
Otherwise it keeps reading the last file in the split

      val rr: RecordReader = new CSVRecordReader()
      rr.initialize(new CollectionInputSplit(files.map(_.toURI).asJava))
      new RecordReaderDataSetIterator(rr, new SelfWritableConverter, batchSize, 0, 1, 2, -1, regression)

      Range(0, config.epochs).foreach { epoch =>
        logger.info(s"training epoch ${epoch + 1}")

        trainIt.reset()
        model.fit(trainIt)
      }