### PR TITLE
Fix issue with reading multiple CSV files with headers

### DIFF
--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/CSVRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/CSVRecordReader.java
@@ -111,6 +111,5 @@ public class CSVRecordReader extends LineRecordReader {
     @Override
     protected void onLocationOpen(URI location) {
         skippedLines = false;
-        skipNumLines = 0;
     }
 }

--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/CSVRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/CSVRecordReader.java
@@ -107,4 +107,10 @@ public class CSVRecordReader extends LineRecordReader {
         super.reset();
         skippedLines = false;
     }
+
+    @Override
+    protected void onLocationOpen(URI location) {
+        skippedLines = false;
+        skipNumLines = 0;
+    }
 }

--- a/canova-api/src/main/java/org/canova/api/records/reader/impl/LineRecordReader.java
+++ b/canova-api/src/main/java/org/canova/api/records/reader/impl/LineRecordReader.java
@@ -88,6 +88,7 @@ public class LineRecordReader extends BaseRecordReader {
                 try {
                     close();
                     iter = IOUtils.lineIterator(new InputStreamReader(locations[currIndex].toURL().openStream()));
+                    onLocationOpen(locations[currIndex]);
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -114,6 +115,7 @@ public class LineRecordReader extends BaseRecordReader {
                 try {
                     close();
                     iter = IOUtils.lineIterator(new InputStreamReader(locations[currIndex].toURL().openStream()));
+                    onLocationOpen(locations[currIndex]);
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -123,6 +125,10 @@ public class LineRecordReader extends BaseRecordReader {
 
             return false;
         }
+    }
+
+    protected void onLocationOpen(URI location) {
+
     }
 
     @Override

--- a/canova-api/src/test/java/org/canova/api/records/reader/impl/CSVRecordReaderTest.java
+++ b/canova-api/src/test/java/org/canova/api/records/reader/impl/CSVRecordReaderTest.java
@@ -1,10 +1,12 @@
 package org.canova.api.records.reader.impl;
 
+import com.sun.corba.se.spi.ior.Writeable;
 import org.apache.commons.io.FileUtils;
 import org.canova.api.io.data.IntWritable;
 import org.canova.api.io.data.Text;
 import org.canova.api.records.writer.impl.CSVRecordWriter;
 import org.canova.api.records.writer.impl.FileRecordWriter;
+import org.canova.api.split.CollectionInputSplit;
 import org.canova.api.split.FileSplit;
 import org.canova.api.split.StringSplit;
 import org.canova.api.util.ClassPathResource;
@@ -12,9 +14,11 @@ import org.canova.api.writable.Writable;
 import org.junit.Test;
 
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -120,6 +124,31 @@ public class CSVRecordReaderTest {
         System.out.println(fileContents);
 
         assertEquals(expected,fileContents);
+    }
+
+    @Test
+    public void testSplit() throws Exception {
+        URI[] arr = new URI[3];
+        try {
+            arr[0] = new ClassPathResource("csvsequence_0.txt").getFile().toURI();
+            arr[1] = new ClassPathResource("csvsequence_1.txt").getFile().toURI();
+            arr[2] = new ClassPathResource("csvsequence_2.txt").getFile().toURI();
+        } catch(Exception e ){
+            throw new RuntimeException(e);
+        }
+
+        CSVRecordReader rr = new CSVRecordReader(1);
+        rr.initialize(new CollectionInputSplit(Arrays.asList(arr)));
+
+        // make sure that there is no header in the lines returned by the reader
+        while (rr.hasNext()) {
+            Collection<Writable> line = rr.next();
+            assertEquals("header is not omitted", 3, line.size());
+
+            for (Writable w : line) {
+                w.toInt();
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
In the following example CSVRecordReader instance is used to read multiple CSV files containing header. But the header is only skipped while reading the first file. This PR introduces a way to reset `skippedLines` flag when advancing to the following file.

    val rr: RecordReader = new CSVRecordReader(1)
    rr.initialize(new CollectionInputSplit(files))
    while (rr.hasNext) {
        Collection<Writable> line = rr.next();
        // line is a header after finishing first file!!
    }
